### PR TITLE
feat: Add PostToolUse hook for automatic rustfmt formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read file_path; if [[ \"$file_path\" =~ \\.rs$ ]]; then (cd rust && cargo fmt); fi; }"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add Rust integration tests for update behavior (including symlink preservation and non-clobbering failures).
 - Add Rust CI workflow for pull requests and document Rust usage in README.
 - Add Codex and gtr configuration files and ignore entries.
+- Add Claude Code PostToolUse hook for automatic `cargo fmt` on Rust file edits.
 
 ### Changed
 - Write `.gitignore` atomically using a temp file + replace (preserving symlinks; hard links may break).


### PR DESCRIPTION
## Summary
- Claude Codeに編集後自動rustfmt実行のためのPostToolUseフックを追加

## Details
`.claude/settings.json`に以下の設定を追加しました：
- `Edit`ツール使用後、Rustファイル(`.rs`)に対して自動的に`rustfmt`を実行
- `Write`ツール使用後、Rustファイル(`.rs`)に対して自動的に`rustfmt`を実行

これにより、コード編集時に一貫したフォーマットが自動的に適用されます。

## Note
Codexについては、現時点でPostToolUse相当の機能が存在しないため設定していません（[openai/codex#2109](https://github.com/openai/codex/issues/2109)で要望として追跡中）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)