### PR TITLE
feat: Add pr-squash-commit-message skill for Conventional Commits

### DIFF
--- a/.claude/skills/pr-squash-commit-message/SKILL.md
+++ b/.claude/skills/pr-squash-commit-message/SKILL.md
@@ -10,6 +10,11 @@ metadata:
 
 Produce a clean, informative squash merge commit message for a GitHub Pull Request following this project's commit message conventions.
 
+## References
+
+- [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+- [Chris Beams: How to Write a Git Commit Message](https://cbea.ms/git-commit/) (especially "what" and "why")
+
 ## Inputs to use (in priority order)
 
 1. Diff (`gh pr diff` or `git diff origin/main`)
@@ -46,9 +51,8 @@ The commit message MUST follow [Conventional Commits v1.0.0](https://www.convent
 
 2–8 short lines or bullet points covering:
 
-- **Why**: Problem or motivation
-- **What**: Changes made
-- **How**: Approach or implementation (if non-obvious)
+- **Why**: Problem or motivation (see [Chris Beams: How to Write a Git Commit Message](https://cbea.ms/git-commit/))
+- **What**: Changes made (see [Chris Beams: How to Write a Git Commit Message](https://cbea.ms/git-commit/))
 - **Impact**: Effects on users, system, or development (SHOULD include)
 
 Use bullets for multiple changes. Keep it scannable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add CLAUDE.md and AGENTS.md for AI agent-specific instructions (#15).
 - Add `mise trust && mise install` to postCreate hook to automatically setup mise environment in new worktrees (#18).
 - Add `.claude/settings.local.json.example` template with `additionalDirectories` configuration (#20).
+- Add `pr-squash-commit-message` Claude Code skill for generating Conventional Commits format squash merge messages (#23).
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Add Claude Code skill to generate squash merge commit messages
- Follow Conventional Commits v1.0.0 format per CONTRIBUTING.md
- Include type selection guide and detailed examples
- Support Impact section as recommended in CONTRIBUTING.md

## Details

This skill helps draft high-quality commit messages for squash merges:
- Analyzes PR diff, title, body, and linked issues
- Generates messages in `<type>: <description> (#PR)` format
- Includes Why/What/How/Impact in the body
- Provides comprehensive examples for feat, fix, and breaking changes

## Test plan

- [x] Skill file created with proper YAML frontmatter
- [x] Examples follow Conventional Commits format
- [x] PR number placement at end of first line
- [ ] Test the skill by running it on a sample PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)