### PR TITLE
docs: replace deprecated nix profile install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Enforce Conventional Commit-style PR titles in CI via amannn/action-semantic-pull-request. (#22, #41)
 - Add example Codex skills for PR creation and squash-merge commit message drafting. (#42)
 - Add Nix flake devShell with Rust tooling, coding agents, and zsh entry. (#43)
-- Add Nix flake package output for `nix run`, `nix profile install`, and `nix build`. (#43)
+- Add Nix flake package output for `nix run`, `nix profile add`, and `nix build`. (#43)
 
 ### Changed
 
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add autonomy and communication guidance for AI agents. (#42)
 - Document `nix develop` devShell usage in contributing guide. (#43)
 - Refine one-line descriptions (README, Nix flake metadata, Homebrew formula, and GitHub repository description). (#43)
+- Update README examples to use `nix profile add` instead of deprecated `nix profile install`. (#PR)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add autonomy and communication guidance for AI agents. (#42)
 - Document `nix develop` devShell usage in contributing guide. (#43)
 - Refine one-line descriptions (README, Nix flake metadata, Homebrew formula, and GitHub repository description). (#43)
-- Update README examples to use `nix profile add` instead of deprecated `nix profile install`. (#PR)
+- Update README examples to use `nix profile add` instead of deprecated `nix profile install`. (#57)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ brew install acevif/tap/ignore
 Install to your profile:
 
 ```sh
-nix profile install github:acevif/ignore
+nix profile add github:acevif/ignore
 ```
 
 Use in your devShell (flake input):
@@ -142,8 +142,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, guidelines, and ho
 
 ## Document status
 
-- Last updated: 2026-01-25
-- Last reviewed: 2026-01-22
+- Last updated: 2026-04-03
+- Last reviewed: 2026-04-03
 
 <details>
 <summary>Date definitions</summary>


### PR DESCRIPTION
## Summary
- update the README Nix install example to use `nix profile add`
- refresh the README document status dates after the docs change
- update the unreleased changelog to reflect the new command and record this docs update

## Testing
- not run (docs-only change)
